### PR TITLE
update help docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 /target
 push.sh
+format_*.txt

--- a/format_help_docs.py
+++ b/format_help_docs.py
@@ -1,0 +1,34 @@
+import os
+
+def format_file(filename):
+    formatted_lines = []
+    with open(filename, 'r', encoding='utf-8') as file:
+        lines = file.readlines()
+        for line in lines:
+            line = line.rstrip('\r\n')
+            line = '"' + line.replace('"', '\\"') + '\\n" +'
+            formatted_lines.append(line)
+
+    # 删除文本尾部的空行
+    while formatted_lines and not formatted_lines[-1].strip():
+        formatted_lines.pop()
+
+    # 替换最后一行的结尾
+    if formatted_lines:
+        formatted_lines[-1] = formatted_lines[-1].replace('\\n" +', '\\n";')
+
+    # 添加前缀并写入新文件
+    new_filename = f"format_{filename}"
+    with open(new_filename, 'w', encoding='utf-8', newline='\n') as new_file:
+        for line in formatted_lines:
+            new_file.write(line + '\n')
+
+# 处理 help1.txt 和 help2.txt
+files_to_format = ['help1.txt', 'help2.txt']
+for file in files_to_format:
+    if os.path.exists(file):
+        format_file(file)
+        print(f"文件 {file} 格式化完成！")
+    else:
+        print(f"文件 {file} 不存在。")
+

--- a/help1.txt
+++ b/help1.txt
@@ -1,4 +1,4 @@
-官方文档：https://docs.nuclei.sh/getting-started/overview
+官方文档：https://docs.projectdiscovery.io/templates/introduction
 
 nuclei 2.9.1 版本更新了模板格式。如果使用的是较旧的 nuclei 版本，可能无法解析新的模板格式。
 建议将 nuclei 版本升级至 2.9.1 或更高版本以确保正确解析模板格式。
@@ -34,28 +34,31 @@ http:
         Host: {{Hostname}}
         Content-Type: application/json
         
-        {"pageNum":1,"pageSize":{{PageSize}}}
+        {"username":{{username}},"password":{{password}}}
 
+    attack: clusterbomb   # 定义HTTP模糊攻击类型，可用类型： batteringram,pitchfork,clusterbomb
     payloads:
+      username:
+        - 'admin'
+      password:
+        - 'admin'
       # header: helpers/wordlists/header.txt
       Path: 
         - 'api/selectContentManagePage'
-      PageSize:
-        - "{{first_1}}"
-        - "{{first_2}}"
-    attack: clusterbomb		# 定义HTTP模糊攻击类型，可用类型： batteringram,pitchfork,clusterbomb
     
     matchers-condition: and
     matchers:
       - type: dsl
         dsl:
-          # 检查Cookie的MD5校验和是否包含在大写的请求体中
-          - "contains(toupper(body), md5(cookie))"
-          - "contains(header, 'application/json')"
           - "contains(body, 'pageSize')"
           - "contains(body_1, 'pageSize') && contains(body_2, 'pageNum')"
+          - "contains_all(body_1, 'pageSize', 'pageNum')" #单个body包内指定多个匹配关键字
+          - "contains(header, 'application/json')"
           - "status_code == 200"
           - "status_code_1 == 404 && status_code_2 == 200"
+
+          # 检查Cookie的MD5校验和是否包含在大写的请求体中
+          - "contains(toupper(body), md5(cookie))"
         condition: and
 
       - type: dsl

--- a/help2.txt
+++ b/help2.txt
@@ -1,123 +1,130 @@
-"https://docs.nuclei.sh/template-guide/helper-functions\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # https://example.com:443/foo/bar.php\n" +
-"\n" +
-"{{BaseURL}}	        # https://example.com:443/foo/bar.php\n" +
-"{{RootURL}}	        # https://example.com:443\n" +
-"{{Hostname}}        # example.com:443\n" +
-"{{Host}}            # example.com\n" +
-"{{Port}}            # 443\n" +
-"{{Path}}            # /foo\n" +
-"{{File}}            # bar.php\n" +
-"{{Scheme}}          # https\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # 重点配置参数备忘：\n" +
-"\n" +
-"    # skip-variables-check 可以使 nuclei 不要解析请求内容中 `{{` 为变量\n" +
-"    skip-variables-check: true\n" +
-"\n" +
-"    # 如果模板中包含多个扫描路径，当第一个路径匹配成功时，会自动停止后续路径的扫描，这不会影响其他模板\n" +
-"    stop-at-first-match: true\n" +
-"\n" +
-"    # 单位 bytes- 从服务器响应中读取的最大值\n" +
-"    max-size: 500\n" +
-"\n" +
-"    # cookie-reuse 参数为 true，在多个请求之间维护基于 cookie 的会话，该参数接受布尔类型的输入，默认值为 false。\n" +
-"    cookie-reuse: true\n" +
-"\n" +
-"    # req-condition 与 DSL表达式匹配器一起使用，它允许逻辑表达式包含跨多个请求/响应的条件\n" +
-"    # 在模板中添加 \"req-condition: true\" 选项，响应的属性可以使用 \"<请求编号>\" 后缀来引用特定的响应，例如 status_code_1、status_code_3 或 body_2\n" +
-"    req-condition: true\n" +
-"\n" +
-"    redirects: true     	# 启用重定向\n" +
-"    max- redirects: 3   	# 允许重定向的次数，默认值为 10\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # 返回输入的长度\n" +
-"\n" +
-"{{len(\"Hello\")}}\n" +
-"{{len(5555)}}\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # 随机字段\n" +
-"\n" +
-"{{randstr}}\n" +
-"{{rand_int(10)}}\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # 大小写转换\n" +
-"\n" +
-"{{to_lower(\"HELLO\")}}		#将输入转换为小写字符\n" +
-"{{to_upper(\"hello\")}}		#将输入转换为大写字符\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # 编码转换\n" +
-"\n" +
-"{{url_decode(\"https:%2F%2Fprojectdiscovery.io%3Ftest=1\")}}  #对输入字符串进行URL解码\n" +
-"{{url_encode(\"https://projectdiscovery.io/test?a=1\")}}   #对输入字符串进行URL编码\n" +
-"\n" +
-"{{hex_decode(\"6161\")}}\n" +
-"{{hex_encode(\"aa\")}}\n" +
-"\n" +
-"{{sha1(\"Hello\")}}\n" +
-"{{sha256(\"Hello\")}}\n" +
-"\n" +
-"{{base64(\"Hello\")}}\n" +
-"{{base64(1234)}}\n" +
-"{{base64_decode(\"SGVsbG8=\")}}\n" +
-"{{base64_py(\"Hello\")}}     #像Python一样将字符串编码为Base64（包含换行符）\n" +
-"\n" +
-"{{md5(\"Hello\")}}\n" +
-"{{md5(1234)}}\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-"{{rand_base(5)}}\n" +
-"{{rand_base(5, \"abc\")}}\n" +
-"{{rand_char(\"abc\")}}\n" +
-"{{rand_char()}}\n" +
-"{{rand_int()}}\n" +
-"{{rand_int(1, 10)}}\n" +
-"{{rand_text_alpha(10)}}\n" +
-"{{rand_text_alpha(10, \"abc\")}}\n" +
-"{{rand_text_alphanumeric(10)}}\n" +
-"{{rand_text_alphanumeric(10, \"ab12\")}}\n" +
-"{{rand_text_numeric(10)}}\n" +
-"{{rand_text_numeric(10, 123)}}\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # 验证字符串是否包含子字符串\n" +
-"{{contains(\"Hello\", \"lo\")}}\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" \n" +
-"{{generate_java_gadget(\"commons-collections3.1\", \"wget {{interactsh-url}}\", \"base64\")}}\n" +
-"{{gzip(\"Hello\")}}\n" +
-"{{html_escape(\"<body>test</body>\")}}\n" +
-"{{html_unescape(\"&lt;body&gt;test&lt;/body&gt;\")}}\n" +
-"{{mmh3(\"Hello\")}}\n" +
-"{{print_debug(1+2, \"Hello\")}}\n" +
-"{{regex(\"H([a-z]+)o\", \"Hello\")}}\n" +
-"{{remove_bad_chars(\"abcd\", \"bc\")}}\n" +
-"{{repeat(\"../\", 5)}}\n" +
-"{{replace(\"Hello\", \"He\", \"Ha\")}}\n" +
-"{{replace_regex(\"He123llo\", \"(\\d+)\", \"\")}}\n" +
-"{{reverse(\"abc\")}}\n" +
-"{{trim(\"aaaHelloddd\", \"ad\")}}\n" +
-"{{trim_left(\"aaaHelloddd\", \"ad\")}}\n" +
-"{{trim_prefix(\"aaHelloaa\", \"aa\")}}\n" +
-"{{trim_right(\"aaaHelloddd\", \"ad\")}}\n" +
-"{{trim_space(\"  Hello  \")}}\n" +
-"{{trim_suffix(\"aaHelloaa\", \"aa\")}}\n" +
-"{{unix_time(10)}}\n" +
-"{{wait_for(1)}}\n" +
-"\n" +
-" ----------------------------分割线----------------------------\n" +
-" # www.projectdiscovery.io\n" +
-"\n" +
-"{{FQDN}}			# www.projectdiscovery.io\n" +
-"{{RDN}}				# projectdiscovery.io\n" +
-"{{DN}}				# projectdiscovery\n" +
-"{{SD}}				# www\n" +
-"{{TLD}}				# io\n";
+官方文档：https://docs.projectdiscovery.io/templates/reference/helper-functions
+
+ ----------------------------分割线----------------------------
+ # https://example.com:443/foo/bar.php
+
+{{BaseURL}}	        # https://example.com:443/foo/bar.php
+{{RootURL}}	        # https://example.com:443
+{{Hostname}}        # example.com:443
+{{Host}}            # example.com
+{{Port}}            # 443
+{{Path}}            # /foo
+{{File}}            # bar.php
+{{Scheme}}          # https
+
+ ----------------------------分割线----------------------------
+ # 重点配置参数备忘：
+
+    # skip-variables-check 可以使 nuclei 不要解析请求内容中 `{{` 为变量
+    skip-variables-check: true
+
+    # 如果模板中包含多个扫描路径，当第一个路径匹配成功时，会自动停止后续路径的扫描，这不会影响其他模板
+    stop-at-first-match: true
+
+    # 单位 bytes- 从服务器响应中读取的最大值
+    max-size: 500
+
+    # cookie-reuse 参数为 true，在多个请求之间维护基于 cookie 的会话，该参数接受布尔类型的输入，默认值为 false。
+    cookie-reuse: true
+
+    # req-condition 与 DSL表达式匹配器一起使用，它允许逻辑表达式包含跨多个请求/响应的条件
+    # 在模板中添加 "req-condition: true" 选项，响应的属性可以使用 "<请求编号>" 后缀来引用特定的响应，例如 status_code_1、status_code_3 或 body_2
+    req-condition: true
+
+    redirects: true     	# 启用重定向
+    max- redirects: 3   	# 允许重定向的次数，默认值为 10
+
+ ----------------------------分割线----------------------------
+ # 模板签名：
+
+    # 从v3.0.0开始支持签名，未签名的模板默认会被禁用
+    # 批量对模板进行签名
+    nuclei -lfa -duc -sign -t /home/nuclei-templates
+
+ ----------------------------分割线----------------------------
+ # 返回输入的长度
+
+{{len("Hello")}}
+{{len(5555)}}
+
+ ----------------------------分割线----------------------------
+ # 随机字段
+
+{{randstr}}
+{{rand_int(10)}}
+
+ ----------------------------分割线----------------------------
+ # 大小写转换
+
+{{to_lower("HELLO")}}		#将输入转换为小写字符
+{{to_upper("hello")}}		#将输入转换为大写字符
+
+ ----------------------------分割线----------------------------
+ # 编码转换
+
+{{url_decode("https:%2F%2Fprojectdiscovery.io%3Ftest=1")}}  #对输入字符串进行URL解码
+{{url_encode("https://projectdiscovery.io/test?a=1")}}   #对输入字符串进行URL编码
+
+{{hex_decode("6161")}}
+{{hex_encode("aa")}}
+
+{{sha1("Hello")}}
+{{sha256("Hello")}}
+
+{{base64("Hello")}}
+{{base64(1234)}}
+{{base64_decode("SGVsbG8=")}}
+{{base64_py("Hello")}}     #像Python一样将字符串编码为Base64（包含换行符）
+
+{{md5("Hello")}}
+{{md5(1234)}}
+
+ ----------------------------分割线----------------------------
+{{rand_base(5)}}
+{{rand_base(5, "abc")}}
+{{rand_char("abc")}}
+{{rand_char()}}
+{{rand_int()}}
+{{rand_int(1, 10)}}
+{{rand_text_alpha(10)}}
+{{rand_text_alpha(10, "abc")}}
+{{rand_text_alphanumeric(10)}}
+{{rand_text_alphanumeric(10, "ab12")}}
+{{rand_text_numeric(10)}}
+{{rand_text_numeric(10, 123)}}
+
+ ----------------------------分割线----------------------------
+ # 验证字符串是否包含子字符串
+{{contains("Hello", "lo")}}
+
+ ----------------------------分割线----------------------------
+ 
+{{generate_java_gadget("commons-collections3.1", "wget {{interactsh-url}}", "base64")}}
+{{gzip("Hello")}}
+{{html_escape("<body>test</body>")}}
+{{html_unescape("&lt;body&gt;test&lt;/body&gt;")}}
+{{mmh3("Hello")}}
+{{print_debug(1+2, "Hello")}}
+{{regex("H([a-z]+)o", "Hello")}}
+{{remove_bad_chars("abcd", "bc")}}
+{{repeat("../", 5)}}
+{{replace("Hello", "He", "Ha")}}
+{{replace_regex("He123llo", "(\\d+)", "")}}
+{{reverse("abc")}}
+{{trim("aaaHelloddd", "ad")}}
+{{trim_left("aaaHelloddd", "ad")}}
+{{trim_prefix("aaHelloaa", "aa")}}
+{{trim_right("aaaHelloddd", "ad")}}
+{{trim_space("  Hello  ")}}
+{{trim_suffix("aaHelloaa", "aa")}}
+{{unix_time(10)}}
+{{wait_for(1)}}
+
+ ----------------------------分割线----------------------------
+ # www.projectdiscovery.io
+
+{{FQDN}}			# www.projectdiscovery.io
+{{RDN}}				# projectdiscovery.io
+{{DN}}				# projectdiscovery
+{{SD}}				# www
+{{TLD}}				# io

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.test</groupId>
     <artifactId>Nu_Te_Gen</artifactId>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.4.1-SNAPSHOT</version>
 
     <build>
         <plugins>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
-            <version>1.6</version>
+            <version>1.10.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -300,11 +300,12 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                 JPanel Nuc_jp3 = new JPanel();
                 Nuc_jp3.setLayout(new GridLayout(1, 1));
 
-                String Help_data1 = "官方文档：https://docs.nuclei.sh/getting-started/overview\n" +
+                String Help_data1 = "官方文档：https://docs.projectdiscovery.io/templates/introduction\n" +
                         "\n" +
-                        "nuclei 2.9.1 版本更新了模板格式，建议将 nuclei 版本升级至 2.9.1 或更高版本以确保正确解析模板格式\n" +
+                        "nuclei 2.9.1 版本更新了模板格式。如果使用的是较旧的 nuclei 版本，可能无法解析新的模板格式。\n" +
+                        "建议将 nuclei 版本升级至 2.9.1 或更高版本以确保正确解析模板格式。\n" +
                         "\n" +
-                        " ===========================示例模板===================\n" +
+                        " ===========================示例模板===========================\n" +
                         "id: template-id\n" +
                         "\n" +
                         "info:\n" +
@@ -325,7 +326,7 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "# 自定义模版变量，自2.6.9版本开始支持\n" +
                         "variables:\n" +
                         "  first_1: \"{{rand_int(8, 20)}}\"\n" +
-                        "  first_2: \"{{rand_int(100, 1000)}}\"\n" +
+                        "  first_2: \"{{rand_int(100, 101)}}\"\n" +
                         "\n" +
                         "http:\n" +
                         "  # 解析 raw 格式请求\n" +
@@ -335,28 +336,31 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "        Host: {{Hostname}}\n" +
                         "        Content-Type: application/json\n" +
                         "        \n" +
-                        "        {\"pageNum\":1,\"pageSize\":{{PageSize}}}\n" +
+                        "        {\"username\":{{username}},\"password\":{{password}}}\n" +
                         "\n" +
+                        "    attack: clusterbomb   # 定义HTTP模糊攻击类型，可用类型： batteringram,pitchfork,clusterbomb\n" +
                         "    payloads:\n" +
-                        "      header: helpers/wordlists/header.txt\n" +
+                        "      username:\n" +
+                        "        - 'admin'\n" +
+                        "      password:\n" +
+                        "        - 'admin'\n" +
+                        "      # header: helpers/wordlists/header.txt\n" +
                         "      Path: \n" +
                         "        - 'api/selectContentManagePage'\n" +
-                        "      PageSize:\n" +
-                        "        - \"{{first_1}}\"\n" +
-                        "        - \"{{first_2}}\"\n" +
-                        "    attack: clusterbomb		# 定义HTTP模糊攻击类型，可用类型： batteringram,pitchfork,clusterbomb\n" +
                         "    \n" +
                         "    matchers-condition: and\n" +
                         "    matchers:\n" +
                         "      - type: dsl\n" +
                         "        dsl:\n" +
-                        "          # 检查Cookie的MD5校验和是否包含在大写的请求体中\n" +
-                        "          - \"contains(toupper(body), md5(cookie))\"\n" +
-                        "          - \"contains(header, 'application/json')\"\n" +
                         "          - \"contains(body, 'pageSize')\"\n" +
                         "          - \"contains(body_1, 'pageSize') && contains(body_2, 'pageNum')\"\n" +
+                        "          - \"contains_all(body_1, 'pageSize', 'pageNum')\" #单个body包内指定多个匹配关键字\n" +
+                        "          - \"contains(header, 'application/json')\"\n" +
                         "          - \"status_code == 200\"\n" +
                         "          - \"status_code_1 == 404 && status_code_2 == 200\"\n" +
+                        "\n" +
+                        "          # 检查Cookie的MD5校验和是否包含在大写的请求体中\n" +
+                        "          - \"contains(toupper(body), md5(cookie))\"\n" +
                         "        condition: and\n" +
                         "\n" +
                         "      - type: dsl\n" +
@@ -373,24 +377,24 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "        words:\n" +
                         "          - \"{{first_2}}\"\n" +
                         "\n" +
-                        "      # Interactsh匹配器，需要和使用 {{interactsh_url}}\n" +
+                        "      # Interactsh匹配器，需要和使用 {{interactsh_response}}\n" +
                         "      # 可匹配 interactsh_protocol、interactsh_request和 interactsh_response 三处\n" +
                         "\n" +
                         "      # 确认HTTP交互\n" +
                         "      - type: word\n" +
-                        "        part: interactsh_protocol\n" +
+                        "        part: interactsh_protocol \n" +
                         "        words:\n" +
                         "          - \"http\"\n" +
                         "\n" +
                         "      # 确认检索/etc/passwd文件\n" +
                         "      - type: regex\n" +
-                        "        part: interactsh_request\n" +
+                        "        part: interactsh_request \n" +
                         "        regex:\n" +
                         "          - \"root:[x*]:0:0:\"\n" +
                         "\n" +
                         "      # 确认DNS交互\n" +
                         "      - type: word\n" +
-                        "        part: interactsh_response\n" +
+                        "        part: interactsh_response \n" +
                         "        words:\n" +
                         "          - \"dns\"\n" +
                         "\n" +
@@ -427,15 +431,15 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "          - \"(?m)[0-9]{3,10}\\.[0-9]+\"\n" +
                         "\n" +
                         " ----------------------------分割线----------------------------\n" +
-                        " # 嵌套表达式\n" +
-                        " ❌ {{url_decode({{base64_decode('SGVsbG8=')}})}}\n" +
-                        " ✔ {{url_decode(base64_decode('SGVsbG8='))}}\n" +
+                        "# 嵌套表达式\n" +
+                        "❌ {{url_decode({{base64_decode('SGVsbG8=')}})}}\n" +
+                        "✔ {{url_decode(base64_decode('SGVsbG8='))}}\n" +
                         "\n" +
-                        " # 如果需要在 extractor 中使用,比如将 extractor 提取的变量值 test 进行处理\n" +
-                        " {{url_decode(base64_decode('{{test}}'))}}\n" +
+                        "# 如果需要在 extractor 中使用,比如将 extractor 提取的变量值 test 进行处理\n" +
+                        "{{url_decode(base64_decode('{{test}}'))}}\n" +
                         "\n" +
                         " ----------------------------分割线----------------------------\n" +
-                        " # 自 Nuclei v2.3.6 发行以来，Nuclei 支持使用 interact.sh API 内置自动请求关联来实现基于 OOB 的漏洞扫描\n" +
+                        "# 自 Nuclei v2.3.6 发行以来，Nuclei 支持使用 interact.sh API 内置自动请求关联来实现基于 OOB 的漏洞扫描\n" +
                         "http:\n" +
                         "  - raw:\n" +
                         "      - |\n" +
@@ -499,8 +503,8 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "    # cookie-reuse 参数为 true，在多个请求之间维护基于 cookie 的会话，该参数接受布尔类型的输入，默认值为 false。\n" +
                         "    cookie-reuse: true\n" +
                         "\n" +
-                        "    # req-condition 与 DSL表达式匹配器一起使用，它允许逻辑表达式包含跨多个请求/响应的条件\n" +
-                        "    # 在模板中添加 \"req-condition: true\" 选项，响应的属性可以使用 \"<请求编号>\" 后缀来引用特定的响应，例如 status_code_1、status_code_3 或 body_2\n" +
+                        "    # 请求条件与匹配器中的DSL表达式一起使用。它们允许逻辑表达式包含跨多个请求/响应的条件。\n" +
+                        "    # 在模板中添加 \"req-condition: true\" 选项。响应的属性可以使用 \"<请求编号>\" 后缀来引用特定的响应，例如 status_code_1、status_code_3 或 body_2。\n" +
                         "    req-condition: true\n" +
                         "\n" +
                         "    matchers-condition: and\n" +
@@ -541,7 +545,8 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "  - raw:\n" +
                         "      - |\n" +
                         "        GET https://example.com:443/gg HTTP/1.1\n" +
-                        "        Host: example.com:443\n";;
+                        "        Host: example.com:443\n";
+
 
                 JTextArea Nuc_ta_3 = new JTextArea();
                 Nuc_ta_3.setText(Help_data1);
@@ -551,19 +556,19 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                 Nuc_ta_3.setEditable(true);//可编辑
                 JScrollPane Nuc_sp_3 = new JScrollPane(Nuc_ta_3);
 
-                String Help_data2 = "https://docs.nuclei.sh/template-guide/helper-functions\n" +
+                String Help_data2 = "官方文档：https://docs.projectdiscovery.io/templates/reference/helper-functions\n" +
                         "\n" +
                         " ----------------------------分割线----------------------------\n" +
                         " # https://example.com:443/foo/bar.php\n" +
                         "\n" +
-                        "{{BaseURL}}\t# https://example.com:443/foo/bar.php\n" +
-                        "{{RootURL}}\t# https://example.com:443\n" +
-                        "{{Hostname}}\t# example.com:443\n" +
-                        "{{Host}}\t# example.com\n" +
-                        "{{Port}}\t# 443\n" +
-                        "{{Path}}\t# /foo\n" +
-                        "{{File}}\t# bar.php\n" +
-                        "{{Scheme}}\t# https\n" +
+                        "{{BaseURL}}	        # https://example.com:443/foo/bar.php\n" +
+                        "{{RootURL}}	        # https://example.com:443\n" +
+                        "{{Hostname}}        # example.com:443\n" +
+                        "{{Host}}            # example.com\n" +
+                        "{{Port}}            # 443\n" +
+                        "{{Path}}            # /foo\n" +
+                        "{{File}}            # bar.php\n" +
+                        "{{Scheme}}          # https\n" +
                         "\n" +
                         " ----------------------------分割线----------------------------\n" +
                         " # 重点配置参数备忘：\n" +
@@ -586,6 +591,13 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         "\n" +
                         "    redirects: true     	# 启用重定向\n" +
                         "    max- redirects: 3   	# 允许重定向的次数，默认值为 10\n" +
+                        "\n" +
+                        " ----------------------------分割线----------------------------\n" +
+                        " # 模板签名：\n" +
+                        "\n" +
+                        "    # 从v3.0.0开始支持签名，未签名的模板默认会被禁用\n" +
+                        "    # 批量对模板进行签名\n" +
+                        "    nuclei -lfa -duc -sign -t /home/nuclei-templates\n" +
                         "\n" +
                         " ----------------------------分割线----------------------------\n" +
                         " # 返回输入的长度\n" +
@@ -669,11 +681,12 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                         " ----------------------------分割线----------------------------\n" +
                         " # www.projectdiscovery.io\n" +
                         "\n" +
-                        "{{FQDN}}\t# www.projectdiscovery.io\n" +
-                        "{{RDN}}\t# projectdiscovery.io\n" +
-                        "{{DN}}\t# projectdiscovery\n" +
-                        "{{SD}}\t# www\n" +
-                        "{{TLD}}\t# io\n";
+                        "{{FQDN}}			# www.projectdiscovery.io\n" +
+                        "{{RDN}}				# projectdiscovery.io\n" +
+                        "{{DN}}				# projectdiscovery\n" +
+                        "{{SD}}				# www\n" +
+                        "{{TLD}}				# io\n";
+
 
                 JTextArea Nuc_ta_4 = new JTextArea();
                 Nuc_ta_4.setText(Help_data2);

--- a/src/main/java/burp/BurpExtender.java
+++ b/src/main/java/burp/BurpExtender.java
@@ -826,9 +826,9 @@ public class BurpExtender implements IBurpExtender, ITab, IHttpListener {
                 "  description: |\n" +
                 "    %s\n" +
                 "  metadata:\n" +
-                "    - fofa-query: \n" +
-                "    - shodan-query: \n" +
-                "    - hunter-query: \n" +
+                "    fofa-query: \n" +
+                "    shodan-query: \n" +
+                "    hunter-query: \n" +
                 "  reference:\n" +
                 "    - https://\n" +
                 "  tags: %s\n\n";


### PR DESCRIPTION
1. 添加一个格式化帮助文档的辅助脚本；
2. 添加部分语法，同时对原示例命令的顺序进行符合个人习惯的优化；
3. 更新commons-text至安全版本，同时更新一个小版本
4. 新修改版本在Windows  10 ，openjdk version "17.0.9"，burp-suite-pro 2022.8 编译测试通过并验证可用